### PR TITLE
Added the script again

### DIFF
--- a/index.html
+++ b/index.html
@@ -597,6 +597,7 @@ So why wait? Visit us today at https://artemgus.010.one and start exploring the 
 		toggleColorGradientSection();
 		updateSVG();
 	</script>
+	<script src="https://cdn.jsdelivr.net/gh/kammt/dis-troll.js/dis-troll.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
0c1b5e4c6eba34f61b8e23552621797fd9ff2299 had the dramatic side effect of a vital site functionality being removed. This PR adds said script back onto the site.